### PR TITLE
[ENHANCEMENT] Use react-intersection-observer and useInView Hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react-dom": "^16.8.6",
     "react-helmet": "^5.2.0",
     "react-icons": "^3.6.1",
+    "react-intersection-observer": "^8.30.3",
     "react-vertical-timeline-component": "^3.3.1"
   },
   "devDependencies": {

--- a/src/components/pages/home/about.js
+++ b/src/components/pages/home/about.js
@@ -4,12 +4,12 @@ import Img from "gatsby-image";
 import PropTypes from "prop-types";
 import React from "react";
 import { Col, Container, Row } from "react-bootstrap";
-import { useIsVisible } from "../../../utils/useIsVisible";
+import { useInView } from "react-intersection-observer";
 import "./about.scss";
 import SkillBar from "./skillBar";
 
 const About = ({ aboutRef }) => {
-  const visible = useIsVisible({ element: aboutRef });
+  const [inViewRef, visible] = useInView();
   const [isVisible, setIsVisible] = React.useState(false);
 
   React.useEffect(() => {
@@ -17,6 +17,14 @@ const About = ({ aboutRef }) => {
       setIsVisible(true);
     }
   }, [visible]);
+
+  const setRefs = React.useCallback(
+    node => {
+      aboutRef.current = node;
+      inViewRef(node);
+    },
+    [inViewRef],
+  );
 
   const { profileImg } = useStaticQuery(
     graphql`
@@ -48,7 +56,7 @@ const About = ({ aboutRef }) => {
     <motion.div
       initial={false}
       animate={isVisible ? "visible" : "hidden"}
-      ref={aboutRef}
+      ref={setRefs}
     >
       <Container fluid="md" ref={aboutRef}>
         <Row>

--- a/src/components/pages/home/skillBar.js
+++ b/src/components/pages/home/skillBar.js
@@ -1,11 +1,10 @@
 import PropTypes from "prop-types";
 import React from "react";
-import { useIsVisible } from "../../../utils/useIsVisible";
+import { useInView } from "react-intersection-observer";
 import "./skillBar.scss";
 
 const SkillBar = ({ skillName, skillStrength }) => {
-  const ref = React.useRef();
-  const visible = useIsVisible({ element: ref });
+  const [ref, visible] = useInView();
 
   React.useEffect(() => {
     if (visible && barWidth === 0) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11273,6 +11273,11 @@ react-intersection-observer@^8.26.2:
   resolved "https://registry.yarnpkg.com/react-intersection-observer/-/react-intersection-observer-8.30.1.tgz#e0ce4835d2834fc712b096aec65230de79eeaadb"
   integrity sha512-BGHGkmWz/d4Gs+44jWkrZBtJ6//HGwouZ9ub+kRRoRfguw2JoDlVrgTDwkQ/deDJAR9keTkQmMilNu+onhqfgw==
 
+react-intersection-observer@^8.30.3:
+  version "8.30.3"
+  resolved "https://registry.yarnpkg.com/react-intersection-observer/-/react-intersection-observer-8.30.3.tgz#99850f0aacc5b474dddb04976e58d7ee9315ba19"
+  integrity sha512-hKYTJUrU99hAf7h1lNY3pjYXt+09BaPNC6fcLw1B8OLJJUDXTWrwzu4hRuztougeRgPYpxmNaTn1FS4F3EQnhA==
+
 react-is@^16.12.0, react-is@^16.3.2, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
# Overview

Replacing the custom `useIsVisible` hook with the use of the `react-intersection-observer` Node module and its `useInView` hook.

## Justification

While Node modules are large, the custom `useIsVisible` hook showed issues with performance and reliability, as fast scrolls don't get caught by its debouncing logic. The `react-intersection-observer` package is a dependency of the already used `react-vertical-timeline` component library making it a very lightweight addition to other parts of the Gatsby project.